### PR TITLE
Remove workaround for msmpi tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,8 @@ source:
     url: https://github.com/mpi4py/mpi4py/releases/download/{{ version }}/mpi4py-{{ version }}.tar.gz
     sha256: 012d716c8b9ed1e513fcc4b18e5af16a8791f51e6d1716baccf988ad355c5a1f
 
-  # MS-MPI Runtime v10.1.2
-  - url: http://download.microsoft.com/download/a/5/2/a5207ca5-1203-491a-8fb8-906fd68ae623/msmpisetup.exe  # [win64]
-    sha256: c305ce3f05d142d519f8dd800d83a4b894fc31bcad30512cefb557feaccbe8b4  # [win64]
-    folder: msmpi  # [win64]
-
 build:
-  number: 6
+  number: 7
   script:
     - export OPAL_PREFIX=$PREFIX   # [mpi == "openmpi"]
 
@@ -43,8 +38,6 @@ requirements:
     - {{ mpi }}
 
 test:
-  source_files:
-    - msmpi/msmpisetup.exe  # [win64]
   commands:
     - |
 
@@ -53,10 +46,6 @@ test:
     - export OMPI_MCA_rmaps_base_oversubscribe=yes          # [mpi == "openmpi"]
     - export OMPI_ALLOW_RUN_AS_ROOT=1                       # [mpi == "openmpi"]
     - export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1               # [mpi == "openmpi"]
-
-    # To run MS-MPI in Conda-Forge's vm image, we need to overwrite the existing MPI Runtime,
-    # see https://github.com/conda-forge/msmpi-feedstock/issues/2#issuecomment-826477768.
-    - msmpi\\msmpisetup.exe -unattend -force -full -verbose || exit 1  # [mpi == "msmpi"]
 
     - python -c "import mpi4py"
     - python -c "import mpi4py.MPI"


### PR DESCRIPTION
I think with https://github.com/conda-forge/msmpi-feedstock/pull/11 testing `msmpi` in downstream packages should just work out of box. Although `msmpi.dll` is fixed to resolve the 32/64 bit issue, I don't think we need a rebuild, so this is just for testing.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
