### PR TITLE
add major version pin to run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,13 @@ source:
     sha256: 820d31ae184d69c17d9b5d55b1d524d56be47d2e6cb318ea4f3e7007feff2ccc
 
 build:
-  number: 0
+  number: 1
   script:
     - export I_MPI_CC=$CC  # [mpi == "impi"]
     - {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
   skip: true  # [win32]
+  run_exports:
+    - {{ pin_subpackage("mpi4py", max_pin="x") }}
 
 requirements:
   build:


### PR DESCRIPTION
when mpi4py is a build dependency, don't assume next major version will be ABI compatible

this will result in e.g. `mpi4py >=4.0.2,<5.0a0` when building with mpi4py 4.0.2. Only affects packages with mpi4py in host dependencies.

ref: https://github.com/conda-forge/fenics-feedstock/issues/212